### PR TITLE
Add setting for move direction affecting smooth rotation orientation

### DIFF
--- a/demo.client.lua
+++ b/demo.client.lua
@@ -19,6 +19,7 @@ local function start()
 		ShouldMountMaterialSounds = true,
 		ShouldMountLookAngle = true,
 		SmoothRotation = smoothRotation,
+		MoveDirectionFactor = 0.25,
 		BodyVisible = bodyVisible,
 		PlatformStandDisablesTurning = true,
 		PlatformStandLocksTurning = false,

--- a/model.client.lua
+++ b/model.client.lua
@@ -7,6 +7,11 @@ RealismClient.start({
 	ShouldMountMaterialSounds = true,
 	ShouldMountLookAngle = true,
 	SmoothRotation = true,
+
+	-- Controls how much the players move direction factors into
+	-- the direction their avatar faces while in first person.
+	MoveDirectionFactor = 0.25,
+
 	BodyVisible = true,
 	PlatformStandDisablesTurning = true,
 	PlatformStandLocksTurning = false,


### PR DESCRIPTION
Slightly orientates the player to face the direction they're moving when in first person or shift lock

Controlled by the `MoveDirectionFactor` config. Can be between 0 and 1, affecting how much the move direction should contribute to the orientation.

https://user-images.githubusercontent.com/83943819/199897600-38f72330-09c4-4697-a4aa-8ed96db0eb0e.mp4

